### PR TITLE
Add styling for front-desk so they can more easily see status

### DIFF
--- a/register/static/css/main.css
+++ b/register/static/css/main.css
@@ -56,3 +56,12 @@ footer>a {
 .dropdown-content li>a {
     color: black;
 }
+
+@media only screen and (max-width: 600px) {
+  .signed-in {
+    border: 25px solid green;
+  }
+  .signed-out {
+    border: 25px solid red;
+  }
+}

--- a/register/templates/register/index.html
+++ b/register/templates/register/index.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load material_forms %}
 
+{% block body_class %}signed-{% if signed_in_records %}in{% else %}out{% endif %}{% endblock %}
+
 {% block page_header %}
     <div class="red-text flow-text center-align" style="font-size: 1rem;">Please use this site AND pen and paper whilst we are testing</div>
     {% if error %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,7 @@
         {% block extra_head %}{% endblock %}
     </head>
 
-    <body>
+    <body class="{% block body_class %}{% endblock %}">
       {% block page_header %}{% endblock %}
       <div class="container">
           {% block content %}{% endblock %}


### PR DESCRIPTION
To make it easier for staff to just hold up their phones and show front-desk their sign-in status, have added border in phone portrait mode. 